### PR TITLE
タグとArticleの記事との紐づけ

### DIFF
--- a/app/controllers/articles_controller.rb
+++ b/app/controllers/articles_controller.rb
@@ -51,7 +51,7 @@ class ArticlesController < ApplicationController
 
   private
     def article_params
-      params.require(:article).permit(:title, :content)
+      params.require(:article).permit(:title, :content, tag_ids: [] )
     end
 
     def set_article

--- a/app/views/articles/_form.html.erb
+++ b/app/views/articles/_form.html.erb
@@ -12,6 +12,10 @@
   <% end %>
 
   <div class="mb-3">
+    <%= form.collection_check_boxes :tag_ids, Tag.all, :id, :name %>
+  </div>
+
+  <div class="mb-3">
     <%= form.label :title, class: "form-label" %>
     <%= form.text_field :title, class: "form-control" %>
   </div>

--- a/app/views/articles/index.html.erb
+++ b/app/views/articles/index.html.erb
@@ -14,7 +14,13 @@
     <tbody>
       <% @articles.each do |article| %>
         <tr>
-          <td><%= article.title %></td>
+          <td>
+            <%= article.title %>
+            <% article.tags.each do |tag| %>
+              <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+            <% end %>
+          </td>
+
           <td><%= article.content %></td>
           <td>
             <%= link_to '詳細', article, class: "btn btn-success" %>

--- a/app/views/articles/show.html.erb
+++ b/app/views/articles/show.html.erb
@@ -9,7 +9,12 @@
   </thead>
   <tbody>
     <tr>
-      <td><%= @article.title %></td>
+      <td>
+        <%= @article.title %>
+        <% @article.tags.each do |tag| %>
+          <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+        <% end %>
+      </td>
       <td><%= @article.content %></td>
       <td>
         <% if current_user.id == @article.user_id%>

--- a/app/views/mypage/show.html.erb
+++ b/app/views/mypage/show.html.erb
@@ -11,17 +11,21 @@
     </tr>
   </thead>
   <tbody>
-      <% @articles.each do |article| %>
-        <tr>
-          <td><%= article.title %></td>
-          <td><%= article.content %></td>
-          <td>
-            <%= link_to '編集', edit_article_path(article), class: "btn btn-warning" %>
-            <%= link_to '詳細', article, class: "btn btn-success" %>
-            <%= link_to '削除', article, class: "btn btn-danger", method: :delete, data: { confirm: '削除しますか?' } %>
-          </td>
-        </tr>
-      <% end %>
+    <% @articles.each do |article| %>
+      <tr>
+        <td>
+          <%= article.title %>
+          <% article.tags.each do |tag| %>
+            <span class="badge rounded-pill bg-primary"><%= tag.name%></span>
+          <% end %>
+        </td>
+        <td><%= article.content %></td>
+        <td>
+          <%= link_to '詳細', article, class: "btn btn-success" %>
+          <%= link_to '削除', article, class: "btn btn-danger", method: :delete, data: { confirm: '削除しますか?' } %>
+        </td>
+      </tr>
+    <% end %>
 
   </tbody>
 </table>

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,8 @@
+# タグの作成
+tags = ["プログラミング", "ハイキング", "趣味", "仕事", "その他"]
+tags.each { |tag| Tag.find_or_create_by!(name: tag) }
+
+
 3.times do |u|
 	user = User.find_or_create_by(email: "user00#{u+1}@example.com") do |user|
     user.password = "password"
@@ -6,6 +11,7 @@
 		50.times do |a|
       user.articles.find_or_create_by(title: "No.#{a+1}: user00#{u+1}の記事") do |article|
         article.content = "No.#{a+1}: user00#{u+1}の記事の本文"
+        article.tag_ids = Tag.all.pluck(:id).sample
       end
 		end
 end


### PR DESCRIPTION
# 概要
- タグと記事との紐付け
# 詳細
- 記事のストロングパラメーターの修正
- seedファイルの修正
　- タグの複数選択
　- 複数表示できること、ランダムでの表示　２パターンの検証
　- 全画面でタグの表示
# 確認したこと
- 新規登録時、更新時の挙動の確認
- 
## 見積もり時間　=> 実際にかかった時間
-  4h00m  =>  7h00m

## 見積もりに対して実際どうだったか
- 単一のタグのヒョ時ができることの確認に時間がかかった。中間テーブルからのデータ取得（id） の実装に時間がかかった。
- 取得情報のストラングパラメータの取得に気づくのに時間がかかった
- 複数情報をDBから取得して配列として受け取るフローのイメージに時間がかかった
- 

### 参 考
- https://www.sejuku.net/blog/46939
- https://pikawaka.com/rails/permit

### UIの変更
<img width="825" alt="image" src="https://user-images.githubusercontent.com/72645811/216828882-c29a7fa0-48f9-4a7a-a862-3151fc008c9a.png">

